### PR TITLE
Añadir CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: output
-          path: ${{ github.event.repository.full_name }}-${{ github.ref }}/**/*
+          path: ${{ github.event.repository.full_name }}-${{ github.ref_name }}/**/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: output
-          path: '**/*'
+          path: ${{ github.event.repository.full_name }}-${{ github.ref }}/**/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,8 @@ jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest
     steps:
-      - run: wget http://github.com/${{ github.event.repository.full_name }}/archive/${{ github.ref }}
-      - run: tar -xvzf $(ls).tar.gz
+      - run: wget http://github.com/${{ github.event.repository.full_name }}/archive/${{ github.ref }}.tar.gz
+      - run: tar -xvzf $(ls)
       - run: zip -r output.zip $(ls --hide=*.tar.gz)/*
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: output
-          path: output.zip
+          path: '**/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: output
-          path: ${{ github.event.repository.full_name }}-${{ github.ref_name }}/**/*
+          path: ${{ github.event.repository.name }}-${{ github.ref_name }}/**/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: GitHub Actions Demo
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: wget http://github.com/${{ github.event.repository.full_name }}/archive/${{ github.ref }}.tar.gz
+      - run: tar -xvzf $(ls).tar.gz
+      - run: zip -r output.zip $(ls --hide=*.tar.gz)/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: output
+          path: output.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest
     steps:
-      - run: wget http://github.com/${{ github.event.repository.full_name }}/archive/${{ github.ref }}.tar.gz
+      - run: wget http://github.com/${{ github.event.repository.full_name }}/archive/${{ github.ref }}
       - run: tar -xvzf $(ls).tar.gz
       - run: zip -r output.zip $(ls --hide=*.tar.gz)/*
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Añadir CI le puede (y le va a) simplificar la vida a la gente que se quiere descargar la version mas nueva sin tener que Descomprimir y Recomprimir por como funciona GitHub